### PR TITLE
🎨 관리자(Admin) API 작성 완료

### DIFF
--- a/src/main/java/com/itschool/study_pod/domain/admin/controller/AdminApiController.java
+++ b/src/main/java/com/itschool/study_pod/domain/admin/controller/AdminApiController.java
@@ -1,5 +1,7 @@
 package com.itschool.study_pod.domain.admin.controller;
 
+import com.itschool.study_pod.domain.studygroup.dto.response.StudyGroupResponse;
+import com.itschool.study_pod.domain.user.dto.response.UserResponse;
 import com.itschool.study_pod.global.base.crud.CrudController;
 import com.itschool.study_pod.global.base.dto.Header;
 import com.itschool.study_pod.domain.admin.dto.request.AdminPasswordUpdateRequest;
@@ -11,10 +13,16 @@ import com.itschool.study_pod.global.base.crud.CrudService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -37,8 +45,56 @@ public class AdminApiController extends CrudController<AdminRequest, AdminRespon
     @ResponseStatus(HttpStatus.NO_CONTENT) // 204, NO_CONTENT
     @PatchMapping("update-pw/{id}")
     public Header<Void> updatePassword(@PathVariable(name = "id") Long id,
-                                                @RequestBody @Valid Header<AdminPasswordUpdateRequest> request) {
+                                       @RequestBody @Valid Header<AdminPasswordUpdateRequest> request) {
         log.info("update password : {}에서 전체 조회 요청", this.getClass().getSimpleName());
         return adminService.updatePassword(id, request);
     }
+
+    // ✅ 추가: 회원 전체 조회
+    @Operation(summary = "회원 목록 조회", description = "전체 회원 목록을 페이징으로 조회합니다.")
+    @GetMapping("/users")
+    public Header<Page<UserResponse>> findAllUsers(Pageable pageable) {
+        return adminService.findAllUsers(pageable);
+    }
+
+    // ✅ 추가: 회원 삭제
+    @Operation(summary = "회원 삭제", description = "지정한 회원을 논리적 삭제 처리합니다.")
+    @PatchMapping("/deleted-user")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteUser(@RequestParam Long userId) {
+        adminService.deleteUser(userId);
+    }
+
+
+    // ✅ 추가: 관리자별 스터디 그룹 조회
+    @Operation(summary = "전체 스터디 그룹 조회", description = "관리자가 모든 스터디 그룹을 조회합니다.")
+    @GetMapping("/study-groups")
+    public Header<List<StudyGroupResponse>> getAllStudyGroups() {
+        return adminService.getAllStudyGroups();
+    }
+
+    // ✅ 추가: 스터디 그룹 삭제
+    @Operation(summary = "스터디 그룹 삭제", description = "지정한 스터디 그룹을 삭제 처리합니다.")
+    @PatchMapping("/deleted-study")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteStudyGroup(@RequestParam @NotNull Long studyGroupId) {
+        adminService.deleteStudyGroup(studyGroupId);
+    }
+
+    // ✅ 추가: 부적절한 유저 정지
+    @Operation(summary = "불량회원 정지", description = "신고되거나 문제가 있는 스터디 유저를 비활성화합니다.")
+    @PatchMapping("/suspend-user")
+    public ResponseEntity<Void> suspendUser(@RequestBody @Valid AdminRequest.SuspendUserRequest request) {
+        adminService.suspendUser(request.getUserId(), request.getReason());
+        return ResponseEntity.noContent().build();
+    }
+
+    // 추가 : 부적절한 스터디 그룹 정지
+    @Operation(summary = "부적절한 스터디 그룹 정지", description = "신고되거나 문제가 있는 스터디 그룹을 정지합니다.")
+    @PatchMapping("/suspend-study-group")
+    public ResponseEntity<Void> suspendStudyGroup(@RequestBody @Valid AdminRequest.SuspendStudyGroupRequest request) {
+        adminService.suspendStudyGroup(request.getStudyGroupId(), request.getReason());
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/itschool/study_pod/domain/admin/dto/request/AdminRequest.java
+++ b/src/main/java/com/itschool/study_pod/domain/admin/dto/request/AdminRequest.java
@@ -1,10 +1,11 @@
 package com.itschool.study_pod.domain.admin.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.*;
 import lombok.*;
+import com.itschool.study_pod.domain.admin.dto.request.AdminRequest.SuspendStudyGroupRequest;
+
 
 @Data // 종합선물세트 : @Getter, @Setter, @ToString, @EqualsAndHashCode, @RequiredArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,8 +27,39 @@ public class AdminRequest {
     @NotEmpty
     private String name;
 
+    @NotEmpty   // ✅ 추가
+    private String createdBy;
+
+    @NotEmpty   // ✅ 추가
+    private String updatedBy;
+
     /*@NotNull
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private AccountRole role;*/
+
+    // ✅ 회원 정지 요청 DTO 통합
+    @Getter
+    @Setter
+    public static class SuspendUserRequest {
+
+        @NotNull(message = "회원 ID는 필수입니다.")
+        private Long userId;
+
+        @NotBlank(message = "정지 사유를 입력해야 합니다.")
+        private String reason;
+    }
+
+    // 추가
+    @Getter
+    @Setter
+    public static class SuspendStudyGroupRequest {
+        @NotNull
+        @JsonProperty("studyGroupId")
+        private Long studyGroupId;
+
+        @NotBlank
+        private String reason;
+    }
+
 
 }

--- a/src/main/java/com/itschool/study_pod/domain/admin/service/AdminService.java
+++ b/src/main/java/com/itschool/study_pod/domain/admin/service/AdminService.java
@@ -1,5 +1,11 @@
 package com.itschool.study_pod.domain.admin.service;
 
+import com.itschool.study_pod.domain.studygroup.dto.response.StudyGroupResponse;
+import com.itschool.study_pod.domain.studygroup.entity.StudyGroup;
+import com.itschool.study_pod.domain.studygroup.repository.StudyGroupRepository;
+import com.itschool.study_pod.domain.user.dto.response.UserResponse;
+import com.itschool.study_pod.domain.user.entity.User;
+import com.itschool.study_pod.domain.user.repository.UserRepository;
 import com.itschool.study_pod.global.base.dto.Header;
 import com.itschool.study_pod.domain.admin.dto.request.AdminPasswordUpdateRequest;
 import com.itschool.study_pod.domain.admin.dto.request.AdminRequest;
@@ -10,10 +16,17 @@ import com.itschool.study_pod.domain.admin.repository.AdminRepository;
 import com.itschool.study_pod.global.base.crud.CrudService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +35,10 @@ public class AdminService extends CrudService<AdminRequest, AdminResponse, Admin
     private final PasswordEncoder bCryptPasswordEncoder;
 
     private final AdminRepository adminRepository;
+
+    // ✅ 추가
+    private final UserRepository userRepository;
+    private final StudyGroupRepository studyGroupRepository;
 
     @Override
     protected JpaRepository<Admin, Long> getBaseRepository() {
@@ -35,9 +52,10 @@ public class AdminService extends CrudService<AdminRequest, AdminResponse, Admin
                 .name(request.getName())
                 .password(bCryptPasswordEncoder.encode(request.getPassword()))
                 .role(AccountRole.ROLE_ADMIN)
+                .createdBy(request.getCreatedBy())      // ✅ 추가
+                .updatedBy(request.getUpdatedBy())      // ✅ 추가
                 .build();
     }
-
 
 
     /*
@@ -53,4 +71,77 @@ public class AdminService extends CrudService<AdminRequest, AdminResponse, Admin
 
         return Header.OK();
     }
+
+    /**
+     * ✅ 추가: 회원 삭제 처리 (논리 삭제)
+     */
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다."));
+        user.setDeleted(true);
+        userRepository.save(user);
+    }
+
+    /**
+     * ✅ 추가: 회원 정지 처리
+     */
+    @Transactional
+    public void suspendUser(Long userId, String reason) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다."));
+        user.setSuspended(true);
+        user.setSuspendReason(reason);
+        userRepository.save(user);
+    }
+
+    /**
+     * ✅ 추가: 스터디 그룹 조회
+     */
+    public Header<List<StudyGroupResponse>> getAllStudyGroups() {
+        List<StudyGroup> groups = studyGroupRepository.findAll(); // 🔄 adminId 없이 전체 조회
+        List<StudyGroupResponse> responseList = groups.stream()
+                .map(StudyGroupResponse::fromEntity)
+                .collect(Collectors.toList());
+        return Header.OK(responseList);
+    }
+
+
+    /**
+     * ✅ 추가: 스터디 그룹 삭제
+     */
+    @Transactional
+    public void deleteStudyGroup(Long studyGroupId) {
+        StudyGroup group = studyGroupRepository.findById(studyGroupId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "스터디 그룹을 찾을 수 없습니다."));
+        group.setDeleted(true);
+        studyGroupRepository.save(group);
+    }
+
+    /**
+     * ✅ 추가: 스터디 그룹 정지
+     */
+    @Transactional
+    public void suspendStudyGroup(Long studyGroupId, String reason) {
+        if (reason == null || reason.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "정지 사유는 필수입니다.");
+        }
+
+        StudyGroup group = studyGroupRepository.findById(studyGroupId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "스터디 그룹을 찾을 수 없습니다. ID=" + studyGroupId));
+
+        group.setSuspended(true);
+        group.setSuspendReason(reason);
+        studyGroupRepository.save(group);
+    }
+
+
+    @Transactional(readOnly = true)
+    public Header<Page<UserResponse>> findAllUsers(Pageable pageable) {
+        Page<UserResponse> users = userRepository.findAll(pageable)
+                .map(UserResponse::fromEntity);
+        return Header.OK(users);
+    }
+
+
 }

--- a/src/main/java/com/itschool/study_pod/domain/studygroup/dto/response/StudyGroupResponse.java
+++ b/src/main/java/com/itschool/study_pod/domain/studygroup/dto/response/StudyGroupResponse.java
@@ -1,5 +1,6 @@
 package com.itschool.study_pod.domain.studygroup.dto.response;
 
+import com.itschool.study_pod.domain.studygroup.entity.StudyGroup;
 import com.itschool.study_pod.domain.subjectarea.dto.response.SubjectAreaResponse;
 import com.itschool.study_pod.domain.user.dto.response.UserResponse;
 import com.itschool.study_pod.global.address.dto.response.SidoResponse;
@@ -79,4 +80,12 @@ public class StudyGroupResponse {
                 .build();
     }
 
+    // ✅ 정적 팩토리 메서드 추가
+    public static StudyGroupResponse fromEntity(StudyGroup group) {
+        return StudyGroupResponse.builder()
+                .id(group.getId())
+                .title(group.getTitle())
+                .description(group.getDescription())
+                .build();
+    }
 }

--- a/src/main/java/com/itschool/study_pod/domain/studygroup/entity/StudyGroup.java
+++ b/src/main/java/com/itschool/study_pod/domain/studygroup/entity/StudyGroup.java
@@ -1,5 +1,6 @@
 package com.itschool.study_pod.domain.studygroup.entity;
 
+import com.itschool.study_pod.domain.admin.entity.Admin;
 import com.itschool.study_pod.domain.studygroup.dto.request.StudyGroupRequest;
 import com.itschool.study_pod.domain.studygroup.dto.response.StudyGroupResponse;
 import com.itschool.study_pod.domain.subjectarea.entity.SubjectArea;
@@ -43,6 +44,19 @@ public class StudyGroup extends IncludeFileUrl<StudyGroupRequest, StudyGroupResp
 
     @Column(nullable = false)
     private Integer maxMembers;
+
+    // ✅ 추가됨: 관리자 정지 여부
+    @Column(name = "is_suspended", nullable = false)
+    private Boolean suspended = false;
+
+    // ✅ 추가됨: 정지 사유
+    @Column(name = "suspend_reason")
+    private String suspendReason;
+
+    // 추가
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id")
+    private Admin admin;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -104,8 +118,8 @@ public class StudyGroup extends IncludeFileUrl<StudyGroupRequest, StudyGroupResp
                 .leader(User.withId(request.getLeader().getId()))
                 .sido(Sido.withId(request.getSido().getSidoCd()))
                 .subjectArea(SubjectArea.withId(request.getSubjectArea().getId()))
-                .keywords(request.getKeywords())
-                .weeklySchedules(request.getWeeklySchedules())
+                .keywords(new HashSet<>(request.getKeywords()))
+                .weeklySchedules(new HashSet<>(request.getWeeklySchedules()))
                 // .fileUrl(request.getFileUrl())
                 .build();
     }
@@ -127,8 +141,8 @@ public class StudyGroup extends IncludeFileUrl<StudyGroupRequest, StudyGroupResp
         this.subjectArea = SubjectArea.withId(request.getSubjectArea().getId());
         this.feeType = request.getFeeType();
         this.amount = request.getAmount();
-        this.keywords = request.getKeywords();
-        this.weeklySchedules = request.getWeeklySchedules();
+        this.keywords = new HashSet<>(request.getKeywords());
+        this.weeklySchedules = new HashSet<>(request.getWeeklySchedules());
 
         // fk 변경 위험, 스터디장 변경은 fetch로 스터디장만 변경하는 다른 api 로직 생성 필요
         // this.leader = User.of(request.getLeader());
@@ -172,6 +186,15 @@ public class StudyGroup extends IncludeFileUrl<StudyGroupRequest, StudyGroupResp
         this.subjectArea = subjectArea;
         this.keywords = req.getKeywords();
         this.weeklySchedules = req.getWeeklySchedules();
+    }
+
+
+    public void setSuspended(boolean suspended) {
+        this.suspended = suspended;
+    }
+
+    public void setSuspendReason(String suspendReason) {
+        this.suspendReason = suspendReason;
     }
 
 }

--- a/src/main/java/com/itschool/study_pod/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/itschool/study_pod/domain/user/dto/response/UserResponse.java
@@ -1,5 +1,6 @@
 package com.itschool.study_pod.domain.user.dto.response;
 
+import com.itschool.study_pod.domain.user.entity.User;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -31,6 +32,16 @@ public class UserResponse {
     public static UserResponse withId(Long id) {
         return UserResponse.builder()
                 .id(id)
+                .build();
+    }
+
+    // ✅ 정적 팩토리 메서드 추가
+    public static UserResponse fromEntity(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .nickname(user.getNickname())
                 .build();
     }
 }

--- a/src/main/java/com/itschool/study_pod/domain/user/entity/User.java
+++ b/src/main/java/com/itschool/study_pod/domain/user/entity/User.java
@@ -21,6 +21,18 @@ public class User extends Account implements Convertible<UserRequest, UserRespon
     @Column(unique = true)
     private String nickname;
 
+    // ✅ 추가됨: 논리 삭제 여부
+    @Column(name = "is_deleted")
+    private Boolean deleted = false;
+
+    // ✅ 추가됨: 정지 여부
+    @Column(name = "is_suspended", nullable = false)
+    private Boolean suspended = false;
+
+    // ✅ 추가됨: 정지 사유
+    @Column(name = "suspend_reason")
+    private String suspendReason;
+
     public static User of(UserRequest request) { // create용
         throw new UnsupportedOperationException("사용되지 않는 메서드. 서비스 계층 toEntity() 참조");
         /*return User.builder()
@@ -31,6 +43,12 @@ public class User extends Account implements Convertible<UserRequest, UserRespon
                 .nickname(request.getNickname())
                 .createdBy(request.getEmail())
                 .build();*/
+    }
+
+    public static User withId(Long id) {
+        return User.builder()
+                .id(id)
+                .build();
     }
 
     // update용
@@ -50,13 +68,13 @@ public class User extends Account implements Convertible<UserRequest, UserRespon
         this.name = request.getName();
 
         // 닉네임 수정 (처음 가입할때 null을 허용하나, null로 update 요청 시 현재 닉네임 유지)
-        this.nickname = request.getNickname() != null? request.getNickname() : this.nickname;
+        this.nickname = request.getNickname() != null ? request.getNickname() : this.nickname;
     }
 
     public void updatePassword(String password) {
         // PATCH 일부 업데이트
         // 비밀번호 null로 수정 불가 (null로 수정 요청 오면 현재 비밀번호 유지)
-        this.password = password != null? password : this.password;
+        this.password = password != null ? password : this.password;
     }
 
     public void updateNickname(String nickname) {
@@ -82,9 +100,16 @@ public class User extends Account implements Convertible<UserRequest, UserRespon
                 .build();
     }
 
-    public static User withId(Long id) {
-        return User.builder()
-                .id(id)
-                .build();
+    // ✅ Setter 추가 (엔티티는 보호되어 있으므로 setter는 최소한으로 공개)
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
+
+    public void setSuspended(boolean suspended) {
+        this.suspended = suspended;
+    }
+
+    public void setSuspendReason(String suspendReason) {
+        this.suspendReason = suspendReason;
     }
 }

--- a/src/main/java/com/itschool/study_pod/global/address/dto/request/SidoRequest.java
+++ b/src/main/java/com/itschool/study_pod/global/address/dto/request/SidoRequest.java
@@ -11,4 +11,11 @@ public class SidoRequest {
     private String sidoCd;
 
     private String sidoNm;
+
+    public static SidoRequest withId(String sidoCd) {
+        return SidoRequest.builder()
+                .sidoCd(sidoCd)
+                .build();
+    }
+
 }

--- a/src/main/java/com/itschool/study_pod/global/base/account/IncludeFileUrl.java
+++ b/src/main/java/com/itschool/study_pod/global/base/account/IncludeFileUrl.java
@@ -18,8 +18,18 @@ public abstract class IncludeFileUrl<Req, Res> extends BaseEntity implements Con
     @Column
     protected String fileUrl;
 
+    // 추가
+    @Column(name = "is_deleted", insertable = false, updatable = false)
+    protected boolean deleted = false;
+
     // 기존 파일 경로 수정
-    public void updateFileUrl(String fileUrl){
+    public void updateFileUrl(String fileUrl) {
         this.fileUrl = fileUrl;
     }
+
+    // 추가
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
+
 }

--- a/src/test/java/com/itschool/study_pod/domain/admin/controller/AdminApiControllerTest.java
+++ b/src/test/java/com/itschool/study_pod/domain/admin/controller/AdminApiControllerTest.java
@@ -5,8 +5,23 @@ import com.itschool.study_pod.MockMvcTest;
 import com.itschool.study_pod.domain.admin.dto.request.AdminRequest;
 import com.itschool.study_pod.domain.admin.entity.Admin;
 import com.itschool.study_pod.domain.admin.repository.AdminRepository;
+import com.itschool.study_pod.domain.studygroup.dto.request.StudyGroupRequest;
+import com.itschool.study_pod.domain.studygroup.entity.StudyGroup;
+import com.itschool.study_pod.domain.studygroup.repository.StudyGroupRepository;
+import com.itschool.study_pod.domain.subjectarea.dto.response.SubjectAreaResponse;
+import com.itschool.study_pod.domain.subjectarea.entity.SubjectArea;
+import com.itschool.study_pod.domain.subjectarea.repository.SubjectAreaRepository;
+import com.itschool.study_pod.domain.user.dto.response.UserResponse;
+import com.itschool.study_pod.domain.user.entity.User;
+import com.itschool.study_pod.domain.user.repository.UserRepository;
+import com.itschool.study_pod.global.address.dto.request.SidoRequest;
+import com.itschool.study_pod.global.address.dto.response.SidoResponse;
+import com.itschool.study_pod.global.address.entity.Sido;
+import com.itschool.study_pod.global.address.repository.SidoRepository;
 import com.itschool.study_pod.global.base.dto.Header;
-import com.itschool.study_pod.global.enumclass.AccountRole;
+import com.itschool.study_pod.global.base.dto.ReferenceDto;
+import com.itschool.study_pod.global.embedable.WeeklySchedule;
+import com.itschool.study_pod.global.enumclass.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,39 +32,74 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.RequestEntity.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Transactional
 class AdminApiControllerTest extends MockMvcTest {
+
+    @Autowired
+    private StudyGroupRepository studyGroupRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SubjectAreaRepository subjectAreaRepository;
+    @Autowired
+    private SidoRepository sidoRepository;
     @Autowired
     private AdminRepository adminRepository;
-
     @Autowired
-    private ObjectMapper objectMapper; // 직렬화와 역직렬화를 위한 클래스
+    private ObjectMapper objectMapper;
+
+    private User leader;
+    private SubjectArea subjectArea;
+    private Sido sido;
+    private StudyGroup savedGroup;
 
     @BeforeEach
-    public void BeforeSetUp() {
-        /*adminRepository.deleteAll(); // 관리자 전부 삭제
+    void setUp() {
+        leader = userRepository.save(User.builder()
+                .email("testuser_" + UUID.randomUUID() + "@example.com")
+                .password("pass1234")
+                .name("테스트유저")
+                .role(AccountRole.ROLE_USER)
+                .build());
 
-        // 관리자 객체 생성
-        Admin user = Admin.builder()
-                .email(UUID.randomUUID() +"@example.com")
-                .password("1234")
-                .name("abc")
-                .build();
+        subjectArea = subjectAreaRepository.save(SubjectArea.builder()
+                .subject(Subject.IT)
+                .build());
 
-        adminRepository.save(user);*/
+        sido = sidoRepository.save(Sido.builder()
+                .sidoCd("11")
+                .sidoNm("서울특별시")
+                .build());
 
+        savedGroup = studyGroupRepository.save(StudyGroup.builder()
+                .title("테스트 스터디")
+                .description("설명")
+                .leader(leader)
+                .subjectArea(subjectArea)
+                .sido(sido)
+                .meetingMethod(MeetingMethod.ONLINE)
+                .recruitmentStatus(RecruitmentStatus.RECRUITING)
+                .maxMembers(5)
+                .feeType(FeeType.MONTHLY)
+                .amount(0L)
+                .build());
     }
 
     @Test
     @DisplayName("저장 테스트")
     void create() throws Exception {
-        // given
         final String url = "/api/admin";
-        final String email = UUID.randomUUID() +"@example.com";
+        final String email = UUID.randomUUID() + "@example.com";
 
         final AdminRequest userRequest = AdminRequest.builder()
                 .email(email)
@@ -57,119 +107,168 @@ class AdminApiControllerTest extends MockMvcTest {
                 .name("저장테스트")
                 .build();
 
-        final Header<AdminRequest> requestBody = Header.<AdminRequest>builder()
-                .data(userRequest).build();
+        final String request = objectMapper.writeValueAsString(
+                Header.<AdminRequest>builder().data(userRequest).build());
 
-        // 객체를 JSON으로 직렬화
-        final String request = objectMapper.writeValueAsString(requestBody);
-
-        // when : 설정한 내용을 바탕으로 요청 전송
         ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post(url)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(request));
 
-        // then : 검증
-        result.andExpect(MockMvcResultMatchers.status().isCreated())
+        result.andExpect(status().isCreated())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value(email));
     }
 
-    // 조회(read) 테스트
     @Test
     @DisplayName("조회 테스트")
     void read() throws Exception {
-        // given
-        final StringBuilder url = new StringBuilder().append("/api/admin");
-        final String email = UUID.randomUUID() +"@example.com";
+        final String email = UUID.randomUUID() + "@example.com";
 
-        // repo 직접 저장
-        final Admin savedAdmin = adminRepository.save(Admin.builder()
+        Admin savedAdmin = adminRepository.save(Admin.builder()
                 .email(email)
                 .password("abcd1234!@#$")
                 .role(AccountRole.ROLE_USER)
                 .name("조회테스트")
                 .build());
 
-        url.append("/").append(savedAdmin.getId());
-
-        // when : 설정한 내용을 바탕으로 요청 전송
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get(url.toString())
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/admin/" + savedAdmin.getId())
                 .accept(MediaType.APPLICATION_JSON_VALUE));
 
-        // then : 검증
-        result.andExpect(MockMvcResultMatchers.status().isOk())
+        result.andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value(email));
     }
 
-    // 수정(update) 테스트
     @Test
     @DisplayName("수정 테스트")
     void update() throws Exception {
-        // given
-        final StringBuilder url = new StringBuilder().append("/api/admin");
-        final String newEmail = "newEmail@example.com";
-        final String newPassword = "Password1234!@#$";
-        final String newName = "새이름";
-        final String newNickname = "nick" + UUID.randomUUID();
-
-        // repo 직접 저장
-        final Admin savedAdmin = adminRepository.save(Admin.builder()
-                .email(UUID.randomUUID() +"@example.com")
+        Admin savedAdmin = adminRepository.save(Admin.builder()
+                .email("old@example.com")
                 .password("abcd1234!@#$")
                 .role(AccountRole.ROLE_USER)
                 .name("수정테스트")
                 .build());
 
-        url.append("/").append(savedAdmin.getId());
-
-        AdminRequest userRequest = AdminRequest.builder()
-                .email(newEmail)
-                .password(newPassword)
-                .name(newName)
+        AdminRequest requestDTO = AdminRequest.builder()
+                .email("newEmail@example.com")
+                .password("Password1234!@#$")
+                .name("새이름")
                 .build();
 
-        final Header<AdminRequest> requestBody = Header.<AdminRequest>builder()
-                .data(userRequest).build();
+        String request = objectMapper.writeValueAsString(
+                Header.<AdminRequest>builder().data(requestDTO).build());
 
-        // 객체를 JSON으로 직렬화
-        final String request = objectMapper.writeValueAsString(requestBody);
-
-        // when : 설정한 내용을 바탕으로 요청 전송
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put(url.toString())
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.put("/api/admin/" + savedAdmin.getId())
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(request));
 
-        // then : 검증
-        result.andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value(newEmail))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.name").value(newName));
+        result.andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("newEmail@example.com"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.name").value("새이름"));
     }
 
-    // 삭제(Delete) 테스트
     @Test
     @DisplayName("삭제 테스트")
     void delete() throws Exception {
-        // given
-        final StringBuilder url = new StringBuilder().append("/api/admin");
-
-        // repo 직접 저장
-        final Admin savedAdmin = adminRepository.save(Admin.builder()
-                .email(UUID.randomUUID() +"@example.com")
+        Admin savedAdmin = adminRepository.save(Admin.builder()
+                .email(UUID.randomUUID() + "@example.com")
                 .password("abcd1234!@#$")
                 .role(AccountRole.ROLE_USER)
-                .name("조회테스트")
+                .name("삭제테스트")
                 .build());
 
-        final Long beforeCount = adminRepository.count();
+        long countBefore = adminRepository.count();
 
-        url.append("/").append(savedAdmin.getId());
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/admin/" + savedAdmin.getId()));
 
-        // when : 설정한 내용을 바탕으로 요청 전송
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete(url.toString()));
+        result.andExpect(status().isNoContent());
+        assertThat(adminRepository.count()).isEqualTo(countBefore - 1);
+    }
 
-        // then : 검증
-        result.andExpect(MockMvcResultMatchers.status().isNoContent());
+    @Test
+    @DisplayName("회원 목록 조회")
+    void testFindAllUsers() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/admin/users?page=0&size=10"))
+                .andExpect(status().isOk());
+    }
 
-        assertThat(adminRepository.count()).isEqualTo(beforeCount - 1);
+    @Test
+    @DisplayName("스터디 그룹 전체 조회")
+    void testGetStudyGroupsByAdmin() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/admin/study-groups"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 삭제")
+    void testDeleteStudyGroup() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/admin/deleted-study")
+                        .param("studyGroupId", savedGroup.getId().toString()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 정지")
+    void testSuspendStudyGroup() throws Exception {
+        // 1. 선행 데이터 준비
+        User user = userRepository.save(User.builder()
+                .email("test@example.com")
+                .name("테스터")
+                .password("1234")
+                .role(AccountRole.ROLE_USER)
+                .build());
+
+        SubjectArea subjectArea = subjectAreaRepository.save(
+                SubjectArea.builder().subject(Subject.IT).build());
+
+        Sido sido = sidoRepository.findById("11")
+                .orElseThrow(() -> new RuntimeException("시도 코드 '11' 없음"));
+
+        StudyGroupRequest request = StudyGroupRequest.builder()
+                .title("테스트 스터디")
+                .description("부적절한 내용")
+                .maxMembers(5)
+                .meetingMethod(MeetingMethod.ONLINE)
+                .recruitmentStatus(RecruitmentStatus.RECRUITING)
+                .feeType(FeeType.MONTHLY)
+                .amount(0L)
+                .leader(ReferenceDto.withId(user.getId()))
+                .subjectArea(ReferenceDto.withId(subjectArea.getId()))
+                .sido(SidoRequest.withId(sido.getSidoCd()))
+                .keywords(Set.of("스프링"))
+                .weeklySchedules(new HashSet<>(Set.of(
+                        WeeklySchedule.of(DayOfWeek.TUESDAY, 19, 0, 21, 0),
+                        WeeklySchedule.of(DayOfWeek.THURSDAY, 20, 0, 22, 0)
+                )))
+                .build();
+
+        StudyGroup savedGroup = studyGroupRepository.save(StudyGroup.of(request));
+
+        // 2. 정지 요청 객체 생성
+        AdminRequest.SuspendStudyGroupRequest suspendRequest = new AdminRequest.SuspendStudyGroupRequest();
+        suspendRequest.setStudyGroupId(savedGroup.getId());
+        suspendRequest.setReason("부적절한 내용입니다");
+
+        // 3. API 호출 & 검증
+        mockMvc.perform(
+                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                                .patch("/api/admin/suspend-study-group")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(suspendRequest))
+                )
+                .andExpect(status().isNoContent());
+    }
+
+
+    @Test
+    @DisplayName("회원 정지 요청")
+    void testSuspendUser() throws Exception {
+        AdminRequest.SuspendUserRequest request = new AdminRequest.SuspendUserRequest();
+        request.setUserId(leader.getId());
+        request.setReason("불법 활동");
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/admin/suspend-user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
     }
 }


### PR DESCRIPTION
관리자 api 풀 리퀘스트 메시지
🔧 feat: 관리자(Admin) API 구현

✅ 구현 내용
- 관리자 생성, 수정, 삭제 API
- 관리자 비밀번호 수정 API
- 전체 관리자 목록 및 단일 조회 기능
- 관리자 페이지네이션 지원
- 관리자에 의한 사용자/스터디그룹 관리 기능 (정지, 삭제 등 포함)

🛠 상세 기능
- `POST /api/admin`: 관리자 계정 생성
- `PUT /api/admin/{id}`: 관리자 정보 수정
- `DELETE /api/admin/{id}`: 관리자 삭제
- `GET /api/admin`: 페이지별 관리자 목록 조회
- `GET /api/admin/{id}`: 관리자 상세 조회
- `PATCH /api/admin/update-pw/{id}`: 관리자 비밀번호 변경
- `GET /api/admin/users`: 전체 사용자 목록 조회
- `GET /api/admin/study-groups`: 전체 스터디 그룹 목록 조회
- `PATCH /api/admin/suspend-user`: 불량 회원 정지
- `PATCH /api/admin/deleted-user`: 회원 논리 삭제 처리
- `PATCH /api/admin/suspend-study-group`: 부적절한 스터디 그룹 정지
- `PATCH /api/admin/deleted-study`: 스터디 그룹 삭제

📁 관련 클래스
- `AdminApiController`, `AdminService`, `AdminRepository`
- `Admin`, `AdminRequest`, `AdminResponse`, `AdminPasswordUpdateRequest`

🧪 테스트
- Controller 및 Repository 단위 테스트 포함